### PR TITLE
Added handling of patch number in version

### DIFF
--- a/tesla_powerwall/__init__.py
+++ b/tesla_powerwall/__init__.py
@@ -374,7 +374,7 @@ class Powerwall(object):
             self._pin_version = None
         else:
             if isinstance(vers, str):
-                self._pin_version = version.parse(vers)
+                self._pin_version = version.parse(vers.split('-')[0])
             elif isinstance(vers, Version):
                 self._pin_version = vers.value
             else:


### PR DESCRIPTION
I've got a Powerwall where the version has a patch number.
```
>>> power_wall.get_status()['version']
'1.46.0-W'
```
This pull request will handling pining of versions which contains a patch number by removing it.