### PR TITLE
Adding "busway" meter type to fix "ValueError: 'busway' is not a valid MeterType"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python Tesla Powerwall API for consuming a local endpoint. The API is by no mean
 
 > Note: This is not an official API provided by Tesla and not affilated in anyways with Tesla.
 
-Powerwall Software versions from 1.47.0 to 1.50.1 as well as 20.40 to 21.39.1 are tested, but others will probably work too. If you encounter an error regarding a change in the API of the Powerwall because your Powerwall has a different version than listed here please open an Issue to report this change so it can be fixed.
+Powerwall Software versions from 1.47.0 to 1.50.1 as well as 20.40 to 22.9.2 are tested, but others will probably work too. If you encounter an error regarding a change in the API of the Powerwall because your Powerwall has a different version than listed here please open an Issue to report this change so it can be fixed.
 
 
 # Table of Contents <!-- omit in TOC -->

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ meters.meters
 #=> [<MeterType.SITE: 'site'>, <MeterType.BATTERY: 'battery'>, <MeterType.LOAD: 'load'>, <MeterType.SOLAR: 'solar'>]
 ```
 
-Available meters are: `solar`, `site`, `load`, `battery` and `generator`. Some of those meters might not be available based on the installation and raise MeterNotAvailableError when accessed.
+Available meters are: `solar`, `site`, `load`, `battery`, `generator`, and `busway`. Some of those meters might not be available based on the installation and raise MeterNotAvailableError when accessed.
 
 #### Current power supply/draw
 

--- a/tesla_powerwall/const.py
+++ b/tesla_powerwall/const.py
@@ -64,6 +64,7 @@ class MeterType(Enum):
     BATTERY = "battery"
     LOAD = "load"
     GENERATOR = "generator"
+    BUSWAY = "busway"
 
 
 class DeviceType(Enum):


### PR DESCRIPTION
Hi! Thank you for developing and maintaining this library! Looking forward to using it as part of Home Assistant.

I've found a missing meter in HomeAssistant 2022.6.6, tesla_powerwall 0.3.17, and Powerwall Gateway 22.9.2, similar to issue #30  (which added "generator"):

> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 191, in _async_refresh
>     self.data = await self._async_update_data()
>   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 150, in _async_update_data
>     return await self.update_method()
>   File "/usr/src/homeassistant/homeassistant/components/powerwall/__init__.py", line 85, in async_update_data
>     return await self.hass.async_add_executor_job(self._update_data)
>   File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
>     result = self.fn(*self.args, **self.kwargs)
>   File "/usr/src/homeassistant/homeassistant/components/powerwall/__init__.py", line 94, in _update_data
>     data = _fetch_powerwall_data(self.power_wall)
>   File "/usr/src/homeassistant/homeassistant/components/powerwall/__init__.py", line 217, in _fetch_powerwall_data
>     meters=power_wall.get_meters(),
>   File "/usr/local/lib/python3.9/site-packages/tesla_powerwall/powerwall.py", line 92, in get_meters
>     return MetersAggregates(self._api.get_meters_aggregates())
>   File "/usr/local/lib/python3.9/site-packages/tesla_powerwall/responses.py", line 104, in __init__
>     self.meters = [MeterType(key) for key in response.keys()]
>   File "/usr/local/lib/python3.9/site-packages/tesla_powerwall/responses.py", line 104, in <listcomp>
>     self.meters = [MeterType(key) for key in response.keys()]
>   File "/usr/local/lib/python3.9/enum.py", line 384, in __call__
>     return cls.__new__(cls, value)
>   File "/usr/local/lib/python3.9/enum.py", line 702, in __new__
>     raise ve_exc
> ValueError: 'busway' is not a valid MeterType

Please let me know if you would like Unit Tests or Readme updates, as I'm initially modeling this PR off of #30, which just contained the enum update. Thank you again!