### PR TITLE
Feature: Take powerwall on/off grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Powerwall Software versions from 1.47.0 to 1.50.1 as well as 20.40 to 22.9.2 are
     - [Powerwalls Serial Numbers](#powerwalls-serial-numbers)
     - [Gateway DIN](#gateway-din)
     - [VIN](#vin)
+    - [Off-grid status](#off-grid-status-set-island-mode)
 ## Installation
 
 Install the library via pip:
@@ -356,4 +357,20 @@ din = powerwall.get_gateway_din()
 
 ```python
 vin = powerwall.get_vin()
+```
+
+### Off-grid status (Set Island mode)
+
+Take your powerwall on- and off-grid similar to the "Take off-grid" button in the Tesla app. 
+
+#### Set powerwall to off-grid (Islanded)
+
+```python
+powerwall.set_island_mode(IslandMode.OFFGRID)
+```
+
+#### Set powerwall to off-grid (Connected)
+
+```python
+powerwall.set_island_mode(IslandMode.ONGRID)
 ```

--- a/tesla_powerwall/__init__.py
+++ b/tesla_powerwall/__init__.py
@@ -5,6 +5,7 @@ from .const import (
     DeviceType,
     GridState,
     GridStatus,
+    IslandMode,
     LineStatus,
     MeterType,
     OperationMode,

--- a/tesla_powerwall/api.py
+++ b/tesla_powerwall/api.py
@@ -4,7 +4,6 @@ from typing import List
 from urllib.parse import urljoin
 
 import requests
-import json
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -129,12 +128,14 @@ class API(object):
         payload: dict,
         headers: dict = {},
     ) -> dict:
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(headers)
         try:
             response = self._http_session.post(
                 url=self.url(path),
-                data=payload,
+                json=payload,
                 timeout=self._timeout,
-                headers=headers,
+                headers=request_headers,
             )
         except (
             requests.exceptions.ConnectionError,
@@ -248,5 +249,4 @@ class API(object):
         return self.post("site_info/site_name", body)
 
     def post_islanding_mode(self, body: dict) -> dict:
-        payload = json.dumps(body)
-        return self.post("v2/islanding/mode", payload, headers={"Content-Type": "application/json"})
+        return self.post("v2/islanding/mode", body)

--- a/tesla_powerwall/api.py
+++ b/tesla_powerwall/api.py
@@ -4,6 +4,7 @@ from typing import List
 from urllib.parse import urljoin
 
 import requests
+import json
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -247,4 +248,5 @@ class API(object):
         return self.post("site_info/site_name", body)
 
     def post_islanding_mode(self, body: dict) -> dict:
-        return self.post("v2/islanding/mode", body)
+        payload = json.dumps(body)
+        return self.post("v2/islanding/mode", payload, headers={"Content-Type": "application/json"})

--- a/tesla_powerwall/api.py
+++ b/tesla_powerwall/api.py
@@ -245,3 +245,6 @@ class API(object):
 
     def post_site_info_site_name(self, body: dict) -> dict:
         return self.post("site_info/site_name", body)
+
+    def post_islanding_mode(self, body: dict) -> dict:
+        return self.post("v2/islanding/mode", body)

--- a/tesla_powerwall/api.py
+++ b/tesla_powerwall/api.py
@@ -128,14 +128,12 @@ class API(object):
         payload: dict,
         headers: dict = {},
     ) -> dict:
-        request_headers = {"Content-Type": "application/json"}
-        request_headers.update(headers)
         try:
             response = self._http_session.post(
                 url=self.url(path),
                 json=payload,
                 timeout=self._timeout,
-                headers=request_headers,
+                headers=headers,
             )
         except (
             requests.exceptions.ConnectionError,

--- a/tesla_powerwall/const.py
+++ b/tesla_powerwall/const.py
@@ -24,6 +24,9 @@ class GridStatus(Enum):
     ISLANDED = "SystemIslandedActive"
     TRANSITION_TO_GRID = "SystemTransitionToGrid"  # Used in version 1.46.0
 
+class IslandMode(Enum):
+    OFFGRID = "intentional_reconnect_failsafe"
+    ONGRID = "backup"
 
 class GridState(Enum):
     COMPLIANT = "Grid_Compliant"

--- a/tesla_powerwall/const.py
+++ b/tesla_powerwall/const.py
@@ -20,8 +20,8 @@ class Roles(Enum):
 
 class GridStatus(Enum):
     CONNECTED = "SystemGridConnected"
-    ISLANEDED_READY = "SystemIslandedReady"
-    ISLANEDED = "SystemIslandedActive"
+    ISLANDED_READY = "SystemIslandedReady"
+    ISLANDED = "SystemIslandedActive"
     TRANSITION_TO_GRID = "SystemTransitionToGrid"  # Used in version 1.46.0
 
 

--- a/tesla_powerwall/const.py
+++ b/tesla_powerwall/const.py
@@ -23,6 +23,7 @@ class GridStatus(Enum):
     ISLANDED_READY = "SystemIslandedReady"
     ISLANDED = "SystemIslandedActive"
     TRANSITION_TO_GRID = "SystemTransitionToGrid"  # Used in version 1.46.0
+    TRANSITION_TO_ISLAND = "SystemTransitionToIsland"
 
 class IslandMode(Enum):
     OFFGRID = "intentional_reconnect_failsafe"

--- a/tesla_powerwall/powerwall.py
+++ b/tesla_powerwall/powerwall.py
@@ -163,7 +163,7 @@ class Powerwall:
         return assert_attribute(self._api.get_config(), "vin", "config")
 
     def set_island_mode(self, mode: IslandMode) -> IslandMode:
-        return assert_attribute(self._api.post_islanding_mode({"island_mode": mode}), "island_mode")
+        return IslandMode(assert_attribute(self._api.post_islanding_mode({"island_mode": mode.value}), "island_mode"))
 
     def get_version(self) -> str:
         version_str = assert_attribute(self._api.get_status(), "version", "status")

--- a/tesla_powerwall/powerwall.py
+++ b/tesla_powerwall/powerwall.py
@@ -9,6 +9,7 @@ from .const import (
     DeviceType,
     GridState,
     GridStatus,
+    IslandMode,
     LineStatus,
     MeterType,
     OperationMode,
@@ -160,6 +161,9 @@ class Powerwall:
 
     def get_vin(self) -> str:
         return assert_attribute(self._api.get_config(), "vin", "config")
+
+    def set_island_mode(self, mode: IslandMode) -> IslandMode:
+        return assert_attribute(self._api.post_islanding_mode({"island_mode": mode}), "island_mode")
 
     def get_version(self) -> str:
         version_str = assert_attribute(self._api.get_status(), "version", "status")

--- a/tests/integration/test_powerwall.py
+++ b/tests/integration/test_powerwall.py
@@ -2,6 +2,7 @@ import unittest
 
 from tesla_powerwall import (
     GridStatus,
+    IslandMode,
     Meter,
     MetersAggregates,
     MeterType,
@@ -96,3 +97,20 @@ class TestPowerwall(unittest.TestCase):
         status.up_time_seconds
         status.start_time
         status.version
+
+    def test_islanding(self) -> None:
+        initial_grid_status = self.powerwall.get_grid_status()
+        self.assertIsInstance(initial_grid_status, GridStatus)
+
+        if(initial_grid_status == GridStatus.CONNECTED):
+            self.powerwall.set_island_mode(IslandMode.OFFGRID)
+            self.assertEqual(self.powerwall.get_grid_status(), GridStatus.ISLANDED)
+            
+            self.powerwall.set_island_mode(IslandMode.ONGRID)
+            self.assertEqual(self.powerwall.get_grid_status(), GridStatus.CONNECTED)
+        else:
+            self.powerwall.set_island_mode(IslandMode.ONGRID)
+            self.assertEqual(self.powerwall.get_grid_status(), GridStatus.CONNECTED)
+
+            self.powerwall.set_island_mode(IslandMode.OFFGRID)
+            self.assertEqual(self.powerwall.get_grid_status(), GridStatus.ISLANDED)

--- a/tests/unit/fixtures/islanding_mode_offgrid.json
+++ b/tests/unit/fixtures/islanding_mode_offgrid.json
@@ -1,0 +1,1 @@
+{"island_mode": "intentional_reconnect_failsafe"}

--- a/tests/unit/fixtures/islanding_mode_ongrid.json
+++ b/tests/unit/fixtures/islanding_mode_ongrid.json
@@ -1,0 +1,1 @@
+{"island_mode": "backup"}

--- a/tests/unit/test_powerwall.py
+++ b/tests/unit/test_powerwall.py
@@ -8,6 +8,7 @@ from tesla_powerwall import (
     API,
     DeviceType,
     GridStatus,
+    IslandMode,
     Meter,
     MeterNotAvailableError,
     MetersAggregates,
@@ -29,6 +30,8 @@ from tests.unit import (
     SITEMASTER_RESPONSE,
     STATUS_RESPONSE,
     SYSTEM_STATUS_RESPONSE,
+    ISLANDING_MODE_ONGRID_RESPONSE,
+    ISLANDING_MODE_OFFGRID_RESPONSE,
 )
 
 
@@ -229,6 +232,32 @@ class TestPowerWall(unittest.TestCase):
         self.assertEqual(batteries[0].energy_charged, 5525740)
         self.assertEqual(batteries[0].energy_discharged, 4659550)
         self.assertEqual(batteries[0].wobble_detected, False)
+
+    @responses.activate
+    def test_islanding_mode_offgrid(self):
+        add(
+            Response(
+                responses.POST,
+                url=f"{ENDPOINT}v2/islanding/mode",
+                json=ISLANDING_MODE_OFFGRID_RESPONSE,
+            )
+        )
+        
+        mode = self.powerwall.set_island_mode(IslandMode.OFFGRID)
+        self.assertEqual(mode, IslandMode.OFFGRID)
+
+    @responses.activate
+    def test_islanding_mode_ongrid(self):
+        add(
+            Response(
+                responses.POST,
+                url=f"{ENDPOINT}v2/islanding/mode",
+                json=ISLANDING_MODE_ONGRID_RESPONSE,
+            )
+        )
+        
+        mode = self.powerwall.set_island_mode(IslandMode.ONGRID)
+        self.assertEqual(mode, IslandMode.ONGRID)
 
     def test_helpers(self):
         resp = {"a": 1}


### PR DESCRIPTION
This PR adds a function to set the islanding mode (this is "Take off-grid" and its inverse in the app).

Note: Been a few years since I've written any python, so opening this up to some feedback nice and early.  I'm expecting there might be some bits that need finessing, but hopefully this is seen as a worthwhile addition.