### PR TITLE
Feature: Set operation mode and Backup percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ powerwall.get_operation_mode()
 #=> <OperationMode.SELF_CONSUMPTION: ...>
 powerwall.get_backup_reserve_percentage()
 #=> 5.000019999999999 (%)
+powerwall.set_operation_mode(OperationMode.SELF_CONSUMPTION)
+#=> <OperationMode.SELF_CONSUMPTION: ...>
+powerwall.set_backup_reserve_percentage(50.5)
+#=> 50.5 (%)
 ```
 
 ### Powerwalls Serial Numbers

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Powerwall Software versions from 1.47.0 to 1.50.1 as well as 20.40 to 22.9.2 are
     - [Gateway DIN](#gateway-din)
     - [VIN](#vin)
     - [Off-grid status](#off-grid-status-set-island-mode)
+- [Testing](#testing)
 ## Installation
 
 Install the library via pip:
@@ -378,3 +379,15 @@ powerwall.set_island_mode(IslandMode.OFFGRID)
 ```python
 powerwall.set_island_mode(IslandMode.ONGRID)
 ```
+
+## Testing
+Make sure when making contributions to this library that you
+
+1. Update any documentation in the README.md file
+2. Run (and write!) unit and integration tests using Tox:
+    - Setup: [Tox documentation](https://tox.wiki/en/latest/installation.html)
+    - Run Unit tests: `python -m tox -e unit`
+    - Run Integration tests: 
+        - *nix based systems: `POWERWALL_IP=<your powerwall IP> POWERWALL_PASSWORD=<your powerwall password> python -m tox -e integration`
+        - A note for windows: the above set-environment-variable syntax won't work.  You should set local environment variables (`ENV_POWERWALL_IP`, `ENV_POWERWALL_PASSWORD`) in windows settings or your script host (e.g. `$env:ENV_POWERWALL_IP = '192.x.x.x'; $env:ENV_POWERWALL_PASSWORD='xxxx'; python -m tox -e integration` for PowerShell).
+        - If you're really stuck, put your IP and PASSWORD values (temporarily) into `tests/integration/__init__.py`.  But don't commit it!

--- a/tesla_powerwall/__init__.py
+++ b/tesla_powerwall/__init__.py
@@ -20,6 +20,7 @@ from .error import (
     MissingAttributeError,
     PowerwallError,
     PowerwallUnreachableError,
+    UnsupportedModeError,
 )
 from .helpers import assert_attribute, convert_to_kw
 from .powerwall import Powerwall

--- a/tesla_powerwall/api.py
+++ b/tesla_powerwall/api.py
@@ -203,6 +203,9 @@ class API(object):
 
     def get_operation(self) -> dict:
         return self.get("operation")
+    
+    def set_operation(self, body: dict) -> dict:
+        return self.post("operation", body)
 
     def get_networks(self) -> list:
         return self.get("networks")

--- a/tesla_powerwall/error.py
+++ b/tesla_powerwall/error.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from .const import MeterType
+from .const import SUPPORTED_OPERATION_MODES, MeterType, OperationMode
 
 
 class PowerwallError(Exception):
@@ -68,5 +68,13 @@ class MeterNotAvailableError(PowerwallError):
         super().__init__(
             "Meter {} is not available at your powerwall. Following meters are available: {} ".format(
                 meter.value, available_meters
+            )
+        )
+
+class UnsupportedModeError(PowerwallError):
+    def __init__(self, operation_mode: OperationMode):
+        super().__init__(
+            "Operation mode {} is not currently supported.  Please try one of: {}".format(
+                operation_mode.value, SUPPORTED_OPERATION_MODES
             )
         )

--- a/tesla_powerwall/powerwall.py
+++ b/tesla_powerwall/powerwall.py
@@ -163,7 +163,10 @@ class Powerwall:
         return assert_attribute(self._api.get_config(), "vin", "config")
 
     def set_island_mode(self, mode: IslandMode) -> IslandMode:
-        return IslandMode(assert_attribute(self._api.post_islanding_mode({"island_mode": mode.value}), "island_mode"))
+        island_mode = assert_attribute(
+            self._api.post_islanding_mode({"island_mode": mode.value}), "island_mode"
+        )
+        return IslandMode(island_mode)
 
     def get_version(self) -> str:
         version_str = assert_attribute(self._api.get_status(), "version", "status")

--- a/tests/integration/test_powerwall.py
+++ b/tests/integration/test_powerwall.py
@@ -11,6 +11,7 @@ from tesla_powerwall import (
     SiteInfo,
     SiteMaster,
 )
+from tesla_powerwall.const import OperationMode
 from tesla_powerwall.responses import PowerwallStatus
 from tests.integration import POWERWALL_IP, POWERWALL_PASSWORD
 
@@ -98,6 +99,32 @@ class TestPowerwall(unittest.TestCase):
         status.up_time_seconds
         status.start_time
         status.version
+
+    def test_setOperationModeAndBackupPercent(self) -> None:
+        # Get initial values
+        initial_operation_mode = self.powerwall.get_operation_mode()
+        self.assertIsInstance(initial_operation_mode, OperationMode)
+        initial_backup_reserve_percentage = self.powerwall.get_backup_reserve_percentage()
+        self.assertIsInstance(initial_backup_reserve_percentage, float)
+
+        # Arrange
+        expected_operation_mode = OperationMode.SELF_CONSUMPTION
+        expected_backup_reserve_percentage = 80
+
+        # Act
+        self.powerwall.set_operation_mode(expected_operation_mode)
+        self.powerwall.set_backup_reserve_percentage(expected_backup_reserve_percentage)
+        observed_operation_mode = self.powerwall.get_operation_mode()
+        observed_backup_reserve_percentage = self.powerwall.get_backup_reserve_percentage()
+        
+        # Assert
+        self.assertEqual(observed_operation_mode, expected_operation_mode)
+        self.assertEqual(observed_backup_reserve_percentage, expected_backup_reserve_percentage)
+
+        # Reset back to initial values
+        self.powerwall.set_operation_mode(initial_operation_mode)
+        self.powerwall.set_backup_reserve_percentage(initial_backup_reserve_percentage)
+
 
     def test_islanding(self) -> None:
         initial_grid_status = self.powerwall.get_grid_status()

--- a/tests/unit/fixtures/operation.json
+++ b/tests/unit/fixtures/operation.json
@@ -1,1 +1,1 @@
-{"real_mode": "self_consumption", "backup_reserve_percent": 5.000019999999999, "freq_shift_load_shed_soe": 0, "freq_shift_load_shed_delta_f": 0}
+{"mode": "self_consumption", "real_mode": "self_consumption", "backup_reserve_percent": 5.000019999999999, "freq_shift_load_shed_soe": 0, "freq_shift_load_shed_delta_f": 0}

--- a/tests/unit/test_powerwall.py
+++ b/tests/unit/test_powerwall.py
@@ -2,7 +2,7 @@ import datetime
 import unittest
 
 import responses
-from responses import GET, Response, add
+from responses import GET, POST, Response, add
 
 from tesla_powerwall import (
     API,
@@ -200,6 +200,9 @@ class TestPowerWall(unittest.TestCase):
     @responses.activate
     def test_set_backup_reserve_percentage(self):
         add(
+            Response(responses.GET, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
+        )
+        add(
             Response(responses.POST, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
         )
         self.assertEqual(
@@ -217,6 +220,9 @@ class TestPowerWall(unittest.TestCase):
 
     @responses.activate
     def test_set_operation_mode(self):
+        add(
+            Response(responses.GET, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
+        )
         add(
             Response(responses.POST, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
         )

--- a/tests/unit/test_powerwall.py
+++ b/tests/unit/test_powerwall.py
@@ -198,12 +198,30 @@ class TestPowerWall(unittest.TestCase):
         )
 
     @responses.activate
+    def test_set_backup_reserve_percentage(self):
+        add(
+            Response(responses.POST, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
+        )
+        self.assertEqual(
+            self.powerwall.set_backup_reserve_percentage(5.000019999999999), 5.000019999999999
+        )
+
+    @responses.activate
     def test_get_operation_mode(self):
         add(
             Response(responses.GET, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
         )
         self.assertEqual(
             self.powerwall.get_operation_mode(), OperationMode.SELF_CONSUMPTION
+        )
+
+    @responses.activate
+    def test_set_operation_mode(self):
+        add(
+            Response(responses.POST, url=f"{ENDPOINT}operation", json=OPERATION_RESPONSE)
+        )
+        self.assertEqual(
+            self.powerwall.set_operation_mode(OperationMode.SELF_CONSUMPTION), OperationMode.SELF_CONSUMPTION
         )
 
     @responses.activate


### PR DESCRIPTION
Was hoping to be able to set my powerwall's Operation Mode and Backup Reserve Percentage programmatically, in order to take advantage of times when power is cheap (by bumping up the backup reserve percent to pull in cheap power).

Pretty much implemented before I hit a roadblock while running integration tests though:

```
tesla_powerwall.error.AccessDeniedError: Access denied for resource /api/operation: Unable to POST to resource: User does not have adequate access rights
``` 

Seems that a regular user credential doesn't have access to POST to this endpoint.  Have you seen this before / any way to access this endpoint? 🙏 