### PR TITLE
Fix error running integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 .js
 .vscode
 .direnv
+
+# MacOS finder stuff
+.DS_Store

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ commands = python -m unittest discover {posargs:tests/unit}
 commands = python -m unittest discover tests/unit
 
 [testenv:integration]
-passenv = POWERWALL_IP POWERWALL_PASSWORD
+passenv = POWERWALL_IP,POWERWALL_PASSWORD
 commands = python -m unittest discover tests/integration


### PR DESCRIPTION
Fixes syntax error in the tox integration tests to gather the environment.

The error would otherwise be:
```
% tox -e integration
integration: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'POWERWALL_IP POWERWALL_PASSWORD'
  integration: FAIL code 1 (0.00 seconds)
  evaluation failed :( (0.03 seconds)
```