### PR TITLE
Add battery percent charged calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ batteries[0].i_out
 #=> -7.4
 batteries[0].grid_state
 #=> GridState.COMPLIANT
+batteries[0].percent_charged
+#=> 52.58
 ```
 
 ### Powerwall Status

--- a/tesla_powerwall/responses.py
+++ b/tesla_powerwall/responses.py
@@ -285,9 +285,14 @@ class BatteryResponse(ResponseBase):
     f_out: float
     i_out: float
     grid_state: GridState
+    percent_charged: float
 
     @staticmethod
     def from_dict(src: dict) -> "BatteryResponse":
+        percent_charged = (
+            100.0 * src["nominal_energy_remaining"] / src["nominal_full_pack_energy"]
+        )
+
         return BatteryResponse(
             src,
             part_number=src["PackagePartNumber"],
@@ -303,4 +308,5 @@ class BatteryResponse(ResponseBase):
             f_out=src["f_out"],
             i_out=src["i_out"],
             grid_state=GridState(src["pinv_grid_state"]),
+            percent_charged=percent_charged,
         )

--- a/tests/integration/test_powerwall.py
+++ b/tests/integration/test_powerwall.py
@@ -87,6 +87,7 @@ class TestPowerwall(unittest.IsolatedAsyncioTestCase):
             battery.capacity
             battery.part_number
             battery.serial_number
+            battery.percent_charged
 
     async def test_grid_status(self) -> None:
         grid_status = await self.powerwall.get_grid_status()

--- a/tests/unit/test_powerwall.py
+++ b/tests/unit/test_powerwall.py
@@ -256,6 +256,7 @@ class TestPowerWall(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(batteries[0].q_out, 30)
         self.assertEqual(batteries[0].v_out, 226.60000000000002)
         self.assertEqual(batteries[0].grid_state, GridState.COMPLIANT)
+        self.assertEqual(batteries[0].percent_charged, 100.0 * 7378 / 14031)
         self.aresponses.assert_plan_strictly_followed()
 
     async def test_islanding_mode_offgrid(self):


### PR DESCRIPTION
It was [requested](https://github.com/home-assistant/core/pull/108339#pullrequestreview-1853324637) to add the battery percent charged calculation into this library instead of the HA integration.