### PR TITLE
Add instantaneous max charge/discharge power accessors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Add `get_instantaneous_max_charge_power` and `get_instantaneous_max_discharge_power` to expose the real-time (BMS-derated) charge/discharge power limits from `system_status`
+
 ## [0.5.2]
 
 - Use yarl for URL parsing by @bdraco (https://github.com/jrester/tesla_powerwall/pull/62)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ await powerwall.get_capacity()
 #=> 28078 (Wh)
 ```
 
+### Max Power
+
+Get the real-time (BMS-derated) maximum charge and discharge power in watt:
+
+```python
+await powerwall.get_instantaneous_max_charge_power()
+#=> 7000 (W)
+await powerwall.get_instantaneous_max_discharge_power()
+#=> 8380 (W)
+```
+
 ### Battery Packs
 
 Get information about the battery packs that are installed:

--- a/tesla_powerwall/powerwall.py
+++ b/tesla_powerwall/powerwall.py
@@ -118,6 +118,20 @@ class Powerwall:
             "system_status",
         )
 
+    async def get_instantaneous_max_charge_power(self) -> int:
+        return assert_attribute(
+            await self._api.get_system_status(),
+            "instantaneous_max_charge_power",
+            "system_status",
+        )
+
+    async def get_instantaneous_max_discharge_power(self) -> int:
+        return assert_attribute(
+            await self._api.get_system_status(),
+            "instantaneous_max_discharge_power",
+            "system_status",
+        )
+
     async def get_batteries(self) -> List[BatteryResponse]:
         batteries = assert_attribute(
             await self._api.get_system_status(), "battery_blocks", "system_status"

--- a/tests/unit/fixtures/system_status.json
+++ b/tests/unit/fixtures/system_status.json
@@ -125,8 +125,8 @@
     }
   ],
   "grid_services_power": 0,
-  "instantaneous_max_charge_power": 0,
-  "instantaneous_max_discharge_power": 0,
+  "instantaneous_max_charge_power": 7000,
+  "instantaneous_max_discharge_power": 8380,
   "inverter_nominal_usable_power": 9200,
   "last_toggle_timestamp": "2021-09-30T18:11:41.110543639+02:00",
   "load_charge_constraint": 0,

--- a/tests/unit/test_powerwall.py
+++ b/tests/unit/test_powerwall.py
@@ -263,6 +263,16 @@ class TestPowerWall(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             batteries[2].disabled_reasons, ["DisabledExcessiveVoltageDrop"]
         )
+
+        self.add_response("system_status", body=SYSTEM_STATUS_RESPONSE)
+        self.assertEqual(
+            await self.powerwall.get_instantaneous_max_charge_power(), 7000
+        )
+
+        self.add_response("system_status", body=SYSTEM_STATUS_RESPONSE)
+        self.assertEqual(
+            await self.powerwall.get_instantaneous_max_discharge_power(), 8380
+        )
         self.aresponses.assert_plan_strictly_followed()
 
     async def test_islanding_mode_offgrid(self):


### PR DESCRIPTION
## Summary

Adds `get_instantaneous_max_charge_power()` and `get_instantaneous_max_discharge_power()` to expose the real-time (BMS-derated) charge/discharge power limits from the `system_status` endpoint.

These complement the existing static `max_charge_power` / `max_discharge_power` nameplate values — the *instantaneous* limits vary with state of charge and temperature, so they reflect what the Powerwall can actually charge/discharge at right now. Implemented with the same `assert_attribute(..., "system_status")` pattern as `get_capacity()` / `get_energy()`.

## Testing

Added assertions to `test_system_status` (fixture updated with non-zero instantaneous values). `pytest tests/unit` → **30 passed**; `ruff check` + `ruff format --check` clean. CHANGELOG + README updated.

## Motivation

Home Assistant core's `powerwall` integration wants to expose these as sensors (real-time power limits are useful for energy automations), but can't read raw `system_status` dicts — so it needs typed accessors here first.
